### PR TITLE
#2529 Update Accredited Programmes a11y statement

### DIFF
--- a/content/accessibility/accredited-programmes.md
+++ b/content/accessibility/accredited-programmes.md
@@ -2,15 +2,13 @@
 
 Last reviewed: 22 July 2026
 
-This accessibility statement applies to the Accredited Programmes service for probation staff.
+This accessibility statement applies to the [Accredited Programmes service](https://accredited-programmes-manage-and-deliver.hmpps.service.justice.gov.uk/) for probation staff.
 
 ## Using this service
 
 This website is run by HMPPS Digital Services.
 
-We want as many people as possible to be able to use this website.
-
-For example, that means you should be able to:
+We want as many people as possible to be able to use this website. For example, that means you should be able to:
 
 - change colours, contrast levels and fonts using browser or device settings
 
@@ -26,7 +24,7 @@ We also make the website text as simple as possible to understand.
 
 ## How accessible this website is
 
-This website is fully compliant with the Web Content Accessibility Guidelines version 2.2 AA standard.
+This website is fully compliant with the [Web Content Accessibility Guidelines version 2.2](https://www.w3.org/TR/WCAG22/) AA standard.
 
 ## Feedback and contact information
 
@@ -46,9 +44,9 @@ HMPPS Digital Services is committed to making its website accessible, in accorda
 
 ### Compliance status
 
-This website was tested in June 2026 against the [Web Content Accessibility Guidelines version 2.2 AA standard](https://www.w3.org/TR/WCAG21/).
+This website was tested in June 2026 against the [Web Content Accessibility Guidelines version 2.2](https://www.w3.org/TR/WCAG21/) AA standard.
 
-This website is fully compliant with the [Web Content Accessibility Guidelines version 2.2 AA standard](https://www.w3.org/TR/WCAG21/).
+This website is fully compliant with the [Web Content Accessibility Guidelines version 2.2](https://www.w3.org/TR/WCAG21/) AA standard.
 
 ## What we’re doing to improve accessibility
 
@@ -56,7 +54,7 @@ While creating this service, we tested with a broad range of users, including us
 
 Ministry of Justice accessibility specialists tested a sample of pages in March 2026 and we improved the service based on their recommendations. For example, we made sure all tables in the service had clear captions for users of assistive technology.
 
-In June and July 2026, we fixed all issues with non-accessible content identified by the User Vision audit to make the service fully compliant with the [Web Content Accessibility Guidelines version 2.2 AA standard](https://www.w3.org/TR/WCAG21/). For example, we made sure links did not disappear when users zoomed to above 200%.
+In June and July 2026, we fixed all issues with non-accessible content identified by the User Vision audit to make the service fully compliant with the [Web Content Accessibility Guidelines version 2.2](https://www.w3.org/TR/WCAG21/) AA standard. For example, we made sure links did not disappear when users zoomed to above 200%.
 
 Over the coming months, we also intend to look at other aspects of the service that do not affect compliance, but where accessibility could still be improved, including 13 observations identified in the User Vision audit. For example, we want to continue improving hint text and labelling to make it clearer to all users what they need to do on some screens.
 
@@ -66,6 +64,6 @@ We're continuing to test the service with users to check how well it is working 
 
 This statement was prepared on 22 July 2026.
 
-This website was tested in June 2026 against the [Web Content Accessibility Guidelines version 2.2 AA standard](https://www.w3.org/TR/WCAG22/). The audit was carried out by [User Vision](https://uservision.co.uk/).
+This website was tested in June 2026 against the [Web Content Accessibility Guidelines version 2.2](https://www.w3.org/TR/WCAG22/) AA standard. The audit was carried out by [User Vision](https://uservision.co.uk/).
 
 The website was retested in July 2026 by User Vision, to check issues we had fixed.

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -15,6 +15,7 @@ generic-service:
     AUDIT_ENABLED: "false"
     PORT: "3000"
 
+    ACCREDITED_PROGRAMMES_URL: "https://accredited-programmes-manage-and-deliver.hmpps.service.justice.gov.uk"
     ALLOCATE_A_PERSON_ON_PROBATION_URL: "https://workforce-management-dev.hmpps.service.justice.gov.uk"
     APPROVED_PREMISES_URL: "https://approved-premises-dev.hmpps.service.justice.gov.uk"
     CONSIDER_A_RECALL_URL: "https://consider-a-recall-dev.hmpps.service.justice.gov.uk"

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -15,6 +15,7 @@ generic-service:
     AUDIT_ENABLED: "false"
     PORT: "3000"
 
+    ACCREDITED_PROGRAMMES_URL: "https://accredited-programmes-manage-and-deliver.hmpps.service.justice.gov.uk"
     ALLOCATE_A_PERSON_ON_PROBATION_URL: "https://workforce-management-preprod.hmpps.service.justice.gov.uk"
     APPROVED_PREMISES_URL: "https://approved-premises-preprod.hmpps.service.justice.gov.uk"
     CONSIDER_A_RECALL_URL: "https://consider-a-recall-preprod.hmpps.service.justice.gov.uk"

--- a/server/config.ts
+++ b/server/config.ts
@@ -77,6 +77,9 @@ export default {
   contentfulFooterLinksEnabled: false,
   environmentName: get('ENVIRONMENT_NAME', 'LOCAL'),
   serviceUrls: {
+    accreditedProgrammes: {
+      url: get('ACCREDITED_PROGRAMMES_URL', 'http://localhost:3001'),
+    },
     allocateAPersonOnProbation: {
       url: get('ALLOCATE_A_PERSON_ON_PROBATION_URL', 'http://localhost:3001', requiredInProduction),
     },

--- a/server/services/utils/getServicesForUser.test.ts
+++ b/server/services/utils/getServicesForUser.test.ts
@@ -5,6 +5,7 @@ import config from '../../config'
 jest.mock('../../config', () => ({
   serviceUrls: {
     environmentName: 'DEV',
+    accreditedProgrammes: { url: 'url' },
     allocateAPersonOnProbation: { url: 'url' },
     approvedPremises: { url: 'url' },
     considerARecall: { url: 'url' },
@@ -54,6 +55,17 @@ describe('getServicesForUser', () => {
         const output = getServicesForUser([])
         expect(!!output.find(service => service.heading === 'Probation Digital Reporting')).toEqual(visible)
       })
+    })
+  })
+
+  describe('Accredited Programmes', () => {
+    test.each`
+      roles                              | visible
+      ${[Role.Probation]}                | ${true}
+      ${[]}                              | ${false}
+    `('user with roles: $roles, can see: $visible', ({ roles, visible }) => {
+      const output = getServicesForUser(roles)
+      expect(!!output.find(service => service.heading === 'Accredited Programmes')).toEqual(visible)
     })
   })
 

--- a/server/services/utils/getServicesForUser.test.ts
+++ b/server/services/utils/getServicesForUser.test.ts
@@ -60,9 +60,9 @@ describe('getServicesForUser', () => {
 
   describe('Accredited Programmes', () => {
     test.each`
-      roles                              | visible
-      ${[Role.Probation]}                | ${true}
-      ${[]}                              | ${false}
+      roles               | visible
+      ${[Role.Probation]} | ${true}
+      ${[]}               | ${false}
     `('user with roles: $roles, can see: $visible', ({ roles, visible }) => {
       const output = getServicesForUser(roles)
       expect(!!output.find(service => service.heading === 'Accredited Programmes')).toEqual(visible)

--- a/server/services/utils/getServicesForUser.ts
+++ b/server/services/utils/getServicesForUser.ts
@@ -5,6 +5,21 @@ import { Role, userHasRoles } from './roles'
 export default (roles: string[]): Service[] => {
   return [
     {
+      id: 'accredited-programmes',
+      heading: 'Accredited Programmes',
+      href: config.serviceUrls.accreditedProgrammes.url,
+      navEnabled: true,
+      enabled: () => ['LOCAL', 'DEV', 'PRE-PRODUCTION'].includes(config.environmentName) &&
+        userHasRoles(
+          [
+            Role.Probation, 
+          ],
+          roles,
+        ),
+      accessibilityHeading: 'Accredited Programmes',
+      accessibilityUrl: '/accessibility/accredited-programmes',
+    },
+    {
       id: 'allocate-a-person-on-probation',
       heading: 'Allocate a Person on Probation',
       href: config.serviceUrls.allocateAPersonOnProbation.url,

--- a/server/services/utils/getServicesForUser.ts
+++ b/server/services/utils/getServicesForUser.ts
@@ -9,8 +9,7 @@ export default (roles: string[]): Service[] => {
       heading: 'Accredited Programmes',
       href: config.serviceUrls.accreditedProgrammes.url,
       navEnabled: true,
-      enabled: () => 
-        ['LOCAL', 'DEV', 'PRE-PRODUCTION'].includes(config.environmentName) && userHasRoles([Role.Probation], roles),
+      enabled: () => ['LOCAL', 'DEV', 'PRE-PRODUCTION'].includes(config.environmentName) && userHasRoles([Role.Probation], roles),
       accessibilityHeading: 'Accredited Programmes',
       accessibilityUrl: '/accessibility/accredited-programmes',
     },

--- a/server/services/utils/getServicesForUser.ts
+++ b/server/services/utils/getServicesForUser.ts
@@ -9,13 +9,8 @@ export default (roles: string[]): Service[] => {
       heading: 'Accredited Programmes',
       href: config.serviceUrls.accreditedProgrammes.url,
       navEnabled: true,
-      enabled: () => ['LOCAL', 'DEV', 'PRE-PRODUCTION'].includes(config.environmentName) &&
-        userHasRoles(
-          [
-            Role.Probation, 
-          ],
-          roles,
-        ),
+      enabled: () => 
+        ['LOCAL', 'DEV', 'PRE-PRODUCTION'].includes(config.environmentName) && userHasRoles([Role.Probation], roles),
       accessibilityHeading: 'Accredited Programmes',
       accessibilityUrl: '/accessibility/accredited-programmes',
     },

--- a/server/services/utils/getServicesForUser.ts
+++ b/server/services/utils/getServicesForUser.ts
@@ -9,7 +9,8 @@ export default (roles: string[]): Service[] => {
       heading: 'Accredited Programmes',
       href: config.serviceUrls.accreditedProgrammes.url,
       navEnabled: true,
-      enabled: () => ['LOCAL', 'DEV', 'PRE-PRODUCTION'].includes(config.environmentName) && userHasRoles([Role.Probation], roles),
+      enabled: () =>
+        ['LOCAL', 'DEV', 'PRE-PRODUCTION'].includes(config.environmentName) && userHasRoles([Role.Probation], roles),
       accessibilityHeading: 'Accredited Programmes',
       accessibilityUrl: '/accessibility/accredited-programmes',
     },

--- a/server/services/utils/roles.ts
+++ b/server/services/utils/roles.ts
@@ -10,6 +10,7 @@ export enum Role {
   MardDutyManager = 'MARD_DUTY_MANAGER',
   MardResidentWorker = 'MARD_RESIDENT_WORKER',
   PrepareACase = 'PREPARE_A_CASE',
+  Probation = 'PROBATION',
   ReadOnly = 'LICENCE_READONLY',
   ResponsibleOfficer = 'LICENCE_RO',
   Support = 'NOMIS_BATCHLOAD',


### PR DESCRIPTION
This PR does the following

- Amends the accessibility statement content.
- Add a Probation role.
- Adds the application URL to the header menu accessible only to users with the Probation role.
  The URL will also only appear on Local, Dev and Pre-Prod environments.
- Adds the statement to the list in the footer accessibility statement.

**Content**
https://github.com/ministryofjustice/hmpps-probation-frontend-component-api/blob/main/content/accessibility/accredited-programmes.md

**Ticket**
https://github.com/ministryofjustice/moj-frontend/issues/2529